### PR TITLE
Allow plugin to decide how to handle exceptions

### DIFF
--- a/src/android/ReflectiveCordovaPlugin.java
+++ b/src/android/ReflectiveCordovaPlugin.java
@@ -48,7 +48,7 @@ public class ReflectiveCordovaPlugin extends CordovaPlugin {
         return false;
     }
 
-    protected void handleUncaughtExceptions(final Throwable e, final Method method, final Object[] methodArgs, final CallbackContext callbackContext) {
+    protected void handleUncaughtExceptions(Throwable e, Method method, Object[] methodArgs, CallbackContext callbackContext) {
         LOG.e(TAG, "Uncaught exception at " + getClass().getSimpleName() + "#" + method.getName(), e);
         callbackContext.error(e.getMessage());
     }

--- a/src/android/ReflectiveCordovaPlugin.java
+++ b/src/android/ReflectiveCordovaPlugin.java
@@ -48,6 +48,11 @@ public class ReflectiveCordovaPlugin extends CordovaPlugin {
         return false;
     }
 
+    protected void handleUncaughtExceptions(final Throwable e, final Method method, final Object[] methodArgs, final CallbackContext callbackContext) {
+        LOG.e(TAG, "Uncaught exception at " + getClass().getSimpleName() + "#" + method.getName(), e);
+        callbackContext.error(e.getMessage());
+    }
+
     private Runnable createCommand(final Method method, final Object[] methodArgs, final CallbackContext callbackContext) {
         return new Runnable() {
             @Override
@@ -58,8 +63,7 @@ public class ReflectiveCordovaPlugin extends CordovaPlugin {
                     if (e instanceof InvocationTargetException) {
                         e = ((InvocationTargetException)e).getTargetException();
                     }
-                    LOG.e(TAG, "Uncaught exception at " + getClass().getSimpleName() + "#" + method.getName(), e);
-                    callbackContext.error(e.getMessage());
+                    handleUncaughtExceptions(e, method, methodArgs, callbackContext);
                 }
             }
         };


### PR DESCRIPTION
Sometimes the child class may want to do additional error handling with uncaught exceptions.

This change enables child class to override the default behaviour.

This change is backward compatible, as default behaviour is to Log.e and invoke callbackContext with error.message