### PR TITLE
FIX: Prevent FireBaseMessagingPlugin methods that lacks arguments fro…

### DIFF
--- a/src/android/ReflectiveCordovaPlugin.java
+++ b/src/android/ReflectiveCordovaPlugin.java
@@ -71,7 +71,11 @@ public class ReflectiveCordovaPlugin extends CordovaPlugin {
             @Override
             public void run() {
                 try {
+                  //FIX: Prevent FireBaseMessagingPlugin methods that lacks arguments from failing
+                  if(CordovaArgs.class.isAssignableFrom(method.getParameterTypes()[0]))
                     method.invoke(ReflectiveCordovaPlugin.this, args, callbackContext);
+                  else
+                    method.invoke(ReflectiveCordovaPlugin.this, callbackContext);
                 } catch (Throwable e) {
                     if (e instanceof InvocationTargetException) {
                         e = ((InvocationTargetException)e).getTargetException();


### PR DESCRIPTION
FireBaseMessagingPlugin fails in my Cordova setup

"devDependencies": {
    "cordova": "^11.0.0",
    "cordova-android": "^11.0.0",
    "cordova-ios": "^6.2.0",
    "cordova-plugin-camera": "^6.0.0",
    "cordova-plugin-device": "^2.1.0",
    "cordova-plugin-firebase-messaging": "^7.0.2",
    "cordova-plugin-injectview": "^1.1.1",
    "cordova-plugin-network-information": "^3.0.0",
    "cordova-plugin-statusbar": "^3.0.0",
    "cordova-support-android-plugin": "~2.0.3",
    "phonegap-plugin-mobile-accessibility": "^1.0.5"
  },